### PR TITLE
v21

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import type { Options } from '@/types/common'
+import type { ClientStorageOptions, DocumentOptions } from '@/types/common'
 
 export const SETTINGS_KEY = 'sync-notion'
 export const CACHE_KEY = 'sync-notion-cache'
@@ -6,14 +6,16 @@ export const GROUP_ID_KEY = 'sync-notion-group-id'
 
 export const DEFAULT_WIDTH = 400
 
-export const DEFAULT_OPTIONS: Options = {
-  // fetch
-  selectedTabKey: 'fetch',
-  proxyUrl: '',
-  integrationToken: '',
+export const DEFAULT_DOCUMENT_OPTIONS: DocumentOptions = {
   databaseId: '',
+  integrationToken: '',
   keyPropertyName: '',
   valuePropertyName: '',
+}
+
+export const DEFAULT_CLIENT_STORAGE_OPTIONS: ClientStorageOptions = {
+  // common
+  selectedTabKey: 'fetch',
   // list
   filterString: '',
   sortValue: 'created_time',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,7 +6,6 @@ import {
   setRelaunchButton,
   showUI,
 } from '@create-figma-plugin/utilities'
-import values from 'lodash/values'
 
 import {
   CACHE_KEY,
@@ -79,25 +78,17 @@ export default async function () {
 
   on<LoadCacheFromUIHandler>('LOAD_CACHE_FROM_UI', async () => {
     // キャッシュのデータをclientStorageから取得
-    const data = await loadSettingsAsync<NotionKeyValue[]>([], CACHE_KEY)
+    const data: NotionKeyValue[] =
+      (await figma.clientStorage.getAsync(CACHE_KEY)) || []
     console.log('cache data', data)
 
-    // なぜかdataがオブジェクトになっている場合があるので、配列に変換
-    const normalizedData = Array.isArray(data)
-      ? data
-      : values<NotionKeyValue>(data)
-    console.log('normalizedData', normalizedData)
-
     // UIに送る
-    emit<LoadCacheFromMainHandler>('LOAD_CACHE_FROM_MAIN', normalizedData)
+    emit<LoadCacheFromMainHandler>('LOAD_CACHE_FROM_MAIN', data)
   })
 
   on<SaveCacheHandler>('SAVE_CACHE', async keyValues => {
-    // まずすでにあるキャッシュを削除
-    await saveSettingsAsync<NotionKeyValue[]>([], CACHE_KEY)
-
     // キャッシュをclientStorageに保存
-    await saveSettingsAsync<NotionKeyValue[]>(keyValues, CACHE_KEY)
+    await figma.clientStorage.setAsync(CACHE_KEY, keyValues)
 
     console.log('save cache success', keyValues)
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,8 @@ import {
 
 import {
   CACHE_KEY,
-  DEFAULT_OPTIONS,
+  DEFAULT_CLIENT_STORAGE_OPTIONS,
+  DEFAULT_DOCUMENT_OPTIONS,
   DEFAULT_WIDTH,
   SETTINGS_KEY,
 } from '@/constants'
@@ -19,7 +20,12 @@ import applyValue from '@/main/applyValue'
 import highlightText from '@/main/highlightText'
 import renameLayer from '@/main/renameLayer'
 
-import type { NotionKeyValue, Options } from '@/types/common'
+import type {
+  ClientStorageOptions,
+  DocumentOptions,
+  NotionKeyValue,
+  Options,
+} from '@/types/common'
 import type {
   ApplyKeyValueHandler,
   ApplyValueHandler,
@@ -51,10 +57,23 @@ export default async function () {
 
   // register event handlers
   on<LoadOptionsFromUIHandler>('LOAD_OPTIONS_FROM_UI', async () => {
-    const options = await loadSettingsAsync<Options>(
-      DEFAULT_OPTIONS,
+    // documentOptionsを取得
+    let documentOptions: DocumentOptions = DEFAULT_DOCUMENT_OPTIONS
+    const pluginData = figma.root.getPluginData(SETTINGS_KEY)
+    if (pluginData) {
+      documentOptions = JSON.parse(pluginData)
+    }
+    console.log('documentOptions', documentOptions)
+
+    // clientStorageOptionsを取得
+    const clientStorageOptions = await loadSettingsAsync<ClientStorageOptions>(
+      DEFAULT_CLIENT_STORAGE_OPTIONS,
       SETTINGS_KEY,
     )
+    console.log('clientStorageOptions', clientStorageOptions)
+
+    // documentOptionsとclientStorageをマージ
+    const options: Options = { ...documentOptions, ...clientStorageOptions }
 
     // main側の言語を切り替え
     await i18n.changeLanguage(options.pluginLanguage)
@@ -65,7 +84,35 @@ export default async function () {
   })
 
   on<SaveOptionsHandler>('SAVE_OPTIONS', async options => {
-    await saveSettingsAsync<Options>(options, SETTINGS_KEY)
+    const newDocumentOptions: DocumentOptions = {
+      databaseId: options.databaseId,
+      integrationToken: options.integrationToken,
+      keyPropertyName: options.keyPropertyName,
+      valuePropertyName: options.valuePropertyName,
+    }
+    const newClientStorageOptions: ClientStorageOptions = {
+      selectedTabKey: options.selectedTabKey,
+      filterString: options.filterString,
+      sortValue: options.sortValue,
+      sortOrder: options.sortOrder,
+      selectedRowId: options.selectedRowId,
+      scrollPosition: options.scrollPosition,
+      targetTextRange: options.targetTextRange,
+      includeComponents: options.includeComponents,
+      includeInstances: options.includeInstances,
+      pluginLanguage: options.pluginLanguage,
+    }
+    console.log('newDocumentOptions', newDocumentOptions)
+    console.log('newClientStorageOptions', newClientStorageOptions)
+
+    // 新しいオプションをDocumentに保存
+    figma.root.setPluginData(SETTINGS_KEY, JSON.stringify(newDocumentOptions))
+
+    // 新しいオプションをclientStorageに保存
+    await saveSettingsAsync<ClientStorageOptions>(
+      newClientStorageOptions,
+      SETTINGS_KEY,
+    )
   })
 
   on<NotifyHandler>('NOTIFY', options => {

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -9,14 +9,17 @@ export type TargetTextRange = 'selection' | 'currentPage' | 'allPages'
 
 export type PluginLanguage = 'en' | 'ja'
 
-export type Options = {
+export type DocumentOptions = {
   // fetch
-  selectedTabKey: SelectedTabKey
-  proxyUrl: string
-  integrationToken: string
   databaseId: string
+  integrationToken: string
   keyPropertyName: string
   valuePropertyName: string
+}
+
+export type ClientStorageOptions = {
+  // common
+  selectedTabKey: SelectedTabKey
   // list
   filterString: string
   sortValue: SortValue
@@ -30,6 +33,8 @@ export type Options = {
   // settings
   pluginLanguage: PluginLanguage
 }
+
+export type Options = DocumentOptions & ClientStorageOptions
 
 export type NotionTitle = {
   type: 'title'

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -22,11 +22,7 @@ import type { ChangeLanguageHandler } from '@/types/eventHandler'
 export default function App() {
   const { t, i18n } = useTranslation()
   const options = useStore()
-  const {
-    updateOptions,
-    loadOptionsFromClientStorage,
-    saveOptionsToClientStorage,
-  } = useOptions()
+  const { updateOptions, loadOptionsFromMain, saveOptionsToMain } = useOptions()
   const { resizeWindow } = useResizeWindow()
   const { loadCacheFromClientStorage } = useCache()
   const [mounted, setMounted] = useState(false)
@@ -78,7 +74,7 @@ export default function App() {
     console.log('App mounted start')
 
     // 設定をclientStorageから取得
-    await loadOptionsFromClientStorage()
+    await loadOptionsFromMain()
 
     // keyValuesのキャッシュをclientStorageから取得
     await loadCacheFromClientStorage()
@@ -96,7 +92,7 @@ export default function App() {
 
   // UI側で設定が更新されたら設定をアップデート
   useUpdateEffect(() => {
-    saveOptionsToClientStorage(options)
+    saveOptionsToMain(options)
   }, [options])
 
   // selectedTab(key)がアップデートされたらselectedTabValueをアップデート

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -28,7 +28,7 @@ export default function App() {
     saveOptionsToClientStorage,
   } = useOptions()
   const { resizeWindow } = useResizeWindow()
-  const { loadCacheFromDocument } = useCache()
+  const { loadCacheFromClientStorage } = useCache()
   const [mounted, setMounted] = useState(false)
   const [selectedTabValue, setSelectedTabValue] =
     useState<SelectedTabValue>('Fetch')
@@ -80,8 +80,8 @@ export default function App() {
     // 設定をclientStorageから取得
     await loadOptionsFromClientStorage()
 
-    // keyValuesのキャッシュをドキュメントから取得
-    await loadCacheFromDocument()
+    // keyValuesのキャッシュをclientStorageから取得
+    await loadCacheFromClientStorage()
 
     // マウント完了
     console.log('App mounted done')

--- a/src/ui/Store.ts
+++ b/src/ui/Store.ts
@@ -1,9 +1,16 @@
 import { create } from 'zustand'
 
-import { DEFAULT_OPTIONS } from '@/constants'
+import {
+  DEFAULT_CLIENT_STORAGE_OPTIONS,
+  DEFAULT_DOCUMENT_OPTIONS,
+} from '@/constants'
 import type { NotionKeyValue, Options } from '@/types/common'
 
-export const useStore = create<Options>(set => DEFAULT_OPTIONS)
+const defaultOptions: Options = {
+  ...DEFAULT_DOCUMENT_OPTIONS,
+  ...DEFAULT_CLIENT_STORAGE_OPTIONS,
+}
+export const useStore = create<Options>(set => defaultOptions)
 
 export const useKeyValuesStore = create<{ keyValues: NotionKeyValue[] }>(
   set => ({

--- a/src/ui/hooks/useCache.ts
+++ b/src/ui/hooks/useCache.ts
@@ -10,9 +10,9 @@ import type {
 } from '@/types/eventHandler'
 
 export default function useCache() {
-  function loadCacheFromDocument() {
+  function loadCacheFromClientStorage() {
     return new Promise<NotionKeyValue[]>(resolve => {
-      console.log('loadCacheFromDocument')
+      console.log('loadCacheFromClientStorage')
 
       once<LoadCacheFromMainHandler>('LOAD_CACHE_FROM_MAIN', keyValues => {
         console.log('cached keyValues', keyValues)
@@ -24,10 +24,10 @@ export default function useCache() {
     })
   }
 
-  function saveCacheToDocument(keyValues: NotionKeyValue[]) {
-    console.log('saveCacheToDocument', keyValues)
+  function saveCacheToClientStorage(keyValues: NotionKeyValue[]) {
+    console.log('saveCacheToClientStorage', keyValues)
     emit<SaveCacheHandler>('SAVE_CACHE', keyValues)
   }
 
-  return { loadCacheFromDocument, saveCacheToDocument }
+  return { loadCacheFromClientStorage, saveCacheToClientStorage }
 }

--- a/src/ui/hooks/useOptions.ts
+++ b/src/ui/hooks/useOptions.ts
@@ -20,9 +20,9 @@ export default function useOptions(isApp?: boolean) {
     useStore.setState({ ...useStore.getState(), ...keyValue })
   }
 
-  function loadOptionsFromClientStorage() {
+  function loadOptionsFromMain() {
     return new Promise<Options>(resolve => {
-      console.log('loadOptionsFromClientStorage')
+      console.log('loadOptionsFromMain')
 
       once<LoadOptionsFromMainHandler>(
         'LOAD_OPTIONS_FROM_MAIN',
@@ -36,14 +36,14 @@ export default function useOptions(isApp?: boolean) {
     })
   }
 
-  function saveOptionsToClientStorage(options: Options) {
-    console.log('saveOptionsToClientStorage', options)
+  function saveOptionsToMain(options: Options) {
+    console.log('saveOptionsToMain', options)
     emit<SaveOptionsHandler>('SAVE_OPTIONS', options)
   }
 
   return {
     updateOptions,
-    loadOptionsFromClientStorage,
-    saveOptionsToClientStorage,
+    loadOptionsFromMain,
+    saveOptionsToMain,
   }
 }

--- a/src/ui/tabs/Fetch.tsx
+++ b/src/ui/tabs/Fetch.tsx
@@ -29,7 +29,7 @@ export default function Fetch() {
   const { updateOptions } = useOptions()
   const { resizeWindow } = useResizeWindow()
   const { fetchNotion } = useNotion()
-  const { saveCacheToDocument } = useCache()
+  const { saveCacheToClientStorage } = useCache()
   const [fetching, setFetching] = useState(false)
   const keyValuesRef = useRef<NotionKeyValue[]>([])
 
@@ -74,8 +74,8 @@ export default function Fetch() {
     // keyValuesをkeyValuesStoreに保存
     useKeyValuesStore.setState({ keyValues: keyValuesRef.current })
 
-    // keyValuesをドキュメントにキャッシュ
-    saveCacheToDocument(keyValuesRef.current)
+    // keyValuesをclientStorageにキャッシュ
+    saveCacheToClientStorage(keyValuesRef.current)
 
     setFetching(false)
 
@@ -90,8 +90,8 @@ export default function Fetch() {
     // keyValuesStoreに空配列を入れる
     useKeyValuesStore.setState({ keyValues: [] })
 
-    // 空配列をドキュメントにキャッシュ
-    saveCacheToDocument([])
+    // 空配列をclientStorageにキャッシュ
+    saveCacheToClientStorage([])
 
     emit<NotifyHandler>('NOTIFY', {
       message: t('notifications.Fetch.clearCache'),


### PR DESCRIPTION
* [Refactor cache handling to use clientStorage instead of document storage](https://github.com/ryonakae/figma-plugin-sync-notion/pull/20/commits/d095b2fce7ac31e60461a82e9fb0bde8207df31d)
* [Refactor options handling to separate DocumentOptions and ClientStorageOptions](https://github.com/ryonakae/figma-plugin-sync-notion/pull/20/commits/59f73ebff1cb9fecd77aa4377b73a3febba0240a)